### PR TITLE
[feat] config openapi specify path

### DIFF
--- a/packages/scalar.aspnetcore/README.md
+++ b/packages/scalar.aspnetcore/README.md
@@ -42,3 +42,17 @@ dotnet build
 dotnet pack --configuration Release
 # then ping marc until we set up ci auto release!
 ```
+
+## Set up Scalar Options
+
+Modified by [john-shika](https://github.com/john-shika/scalar), you can config OpenApi Specify Path \(0-0)/ yee!
+
+```c#
+app.MapOpenApi("/openapi/{documentName}.json");
+
+app.MapScalarApiReference((ScalarOptions options) =>
+{
+    options.OpenApiSpecPath = "/openapi/{documentName}.json";
+    options.Theme = "purple";
+});
+```

--- a/packages/scalar.aspnetcore/ScalarOptions.cs
+++ b/packages/scalar.aspnetcore/ScalarOptions.cs
@@ -6,6 +6,9 @@ namespace Scalar.AspNetCore;
 public class ScalarOptions
 {
     [JsonIgnore]
+    public string OpenApiSpecPath { get; set; } = "/openapi/{documentName}.json";
+    
+    [JsonIgnore]
     public string EndpointPathPrefix { get; set; } = "/scalar";
 
     [JsonIgnore] 


### PR DESCRIPTION
Gracias!
I'm John Shika, I love your project, I want added feature for `Scalar.AspNetCore`.

**Feature**
Added feature for config OpenApi specify path, and encode configuration JSON string into Base64.

Look like this one!

```c#
app.MapOpenApi("/openapi/{documentName}.json");

app.MapScalarApiReference((ScalarOptions options) =>
{
    options.OpenApiSpecPath = "/openapi/{documentName}.json";
    options.Theme = "purple";
});
```